### PR TITLE
Fixes for python2

### DIFF
--- a/package/build.py
+++ b/package/build.py
@@ -4,20 +4,20 @@ from torch.utils.ffi import create_extension
 
 this_file = os.path.dirname(__file__)
 
-sources = ['src/my_lib.c']
-headers = ['src/my_lib.h']
+sources = ['my_package/src/my_lib.c']
+headers = ['my_package/src/my_lib.h']
 defines = []
 with_cuda = False
 
 if torch.cuda.is_available():
     print('Including CUDA code.')
-    sources += ['src/my_lib_cuda.c']
-    headers += ['src/my_lib_cuda.h']
+    sources += ['my_package/src/my_lib_cuda.c']
+    headers += ['my_package/src/my_lib_cuda.h']
     defines += [('WITH_CUDA', None)]
     with_cuda = True
 
 ffi = create_extension(
-    '_ext.my_lib',
+    'my_package._ext.my_lib',
     package=True,
     headers=headers,
     sources=sources,

--- a/package/setup.py
+++ b/package/setup.py
@@ -5,7 +5,7 @@ import sys
 
 from setuptools import setup, find_packages
 
-import my_package.build
+import build
 
 this_file = os.path.dirname(__file__)
 
@@ -20,11 +20,11 @@ setup(
     install_requires=["cffi>=1.0.0"],
     setup_requires=["cffi>=1.0.0"],
     # Exclude the build files.
-    packages=find_packages(exclude=["my_package.build"]),
+    packages=find_packages(exclude=["build"]),
     # Package where to put the extensions. Has to be a prefix of build.py.
-    ext_package="my_package",
+    ext_package="",
     # Extensions to compile.
     cffi_modules=[
-        os.path.join(this_file, "my_package/build.py:ffi")
+        os.path.join(this_file, "build.py:ffi")
     ],
 )


### PR DESCRIPTION
Fixes #2 

This addresses an issue with the `cfft` package for Python 2. The generated `.so` file must be generated from the project root. Otherwise, there is a `SystemError` when importing the package.

I tested this both on Python 2 and 3.