### PR TITLE
Add c99 compile flag to example

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -22,7 +22,8 @@ ffi = create_extension(
     sources=sources,
     define_macros=defines,
     relative_to=__file__,
-    with_cuda=with_cuda
+    with_cuda=with_cuda,
+    extra_compile_args=["-std=c99"]
 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `-std=c99` so that cffi example can be compiled with gcc 4.8, otherwise it gives `'for' loop initial declarations are only allowed in C99 mode` error message. (See https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-trusty-py3.6-gcc4.8-build/1435/console)